### PR TITLE
Add ability to write build metadata as image labels

### DIFF
--- a/vars/patchBuildConfigOutputLabels.groovy
+++ b/vars/patchBuildConfigOutputLabels.groovy
@@ -1,0 +1,31 @@
+// When using the non-declarative pipeline, git env variables need to be set through scm checkout
+class PatchBuildConfigOutputLabelsInput implements Serializable{
+    String domainPrefix = "com.redhat"
+    String bcName
+}
+
+def call(Map input) {
+    call(new PatchBuildConfigOutputLabelsInput(input))
+} 
+
+def call(PatchBuildConfigOutputLabelsInput input) {
+    assert input.bcName?.trim() : "Param bcName (build config name) should be defined"
+
+    def patch = [
+            spec: [
+                output : [
+                    imageLabels : [ 
+                        [ name: "${input.domainPrefix}.jenkins.build.url", value: "${env.BUILD_URL}" ],
+                        [ name: "${input.domainPrefix}.jenkins.build.tag", value: "${env.BUILD_NUMBER}"],
+                        [ name: "${input.domainPrefix}.git.branch", value: "${env.GIT_BRANCH}"],
+                        [ name: "${input.domainPrefix}.git.url", value: "${env.GIT_URL}"],
+                        [ name: "${input.domainPrefix}.git.commit", value: "${env.GIT_COMMIT}"]
+                    ]
+                ]
+            ] 
+        ]
+
+    def patchJson = groovy.json.JsonOutput.toJson(patch)
+
+    sh "oc patch bc ${input.bcName} -p '${patchJson}'"
+}

--- a/vars/patchBuildConfigOutputLabels.txt
+++ b/vars/patchBuildConfigOutputLabels.txt
@@ -4,7 +4,7 @@ Patches the build config to add jenkins and git build information.
 
 Parameters:
 
-patchBuildConfigOutputLabes(bcName: String (required), domainPrefix: String (optional))
+patchBuildConfigOutputLabels(bcName: String (required), domainPrefix: String (optional, default: com.redhat))
 
 Sample usage:
 

--- a/vars/patchBuildConfigOutputLabels.txt
+++ b/vars/patchBuildConfigOutputLabels.txt
@@ -1,0 +1,29 @@
+# patchBuildConfigOutputLabels
+
+Patches the build config to add jenkins and git build information.
+
+Parameters:
+
+patchBuildConfigOutputLabes(bcName: String (required), domainPrefix: String (optional))
+
+Sample usage:
+
+Intended to run before the container build
+```
+stage('Container Build'){
+  steps {
+    patchBuildConfigOutputLabels(bcName: 'my-app', domainPrefix: 'org.example')
+    script {
+      openshift.withCluster () {
+        openshift.startBuild( "${APP_NAME} --from-dir=${SOURCE_CONTEXT_DIR} -w" )
+      }
+    }
+  }
+}
+```
+
+Include this library by adding this before "pipeline" in your Jenkins:
+```
+library identifier: "pipeline-library@master", retriever: modernSCM(
+  [$class: "GitSCMSource",
+   remote: "https://github.com/redhat-cop/pipeline-library.git"])


### PR DESCRIPTION
This adds the ability to write build information into the image by patching the build config with values from git and jenkins by updating the labels in the build config before running the container build.

Intended to be called in the Jenkinsfile like:

```
stage('Container Build'){
  steps {
    patchBuildConfigOutputLabels(bcName: "${APP_NAME}", domainPrefix: 'org.example')
    script {
      openshift.withCluster () {
        openshift.startBuild( "${APP_NAME} --from-dir=${SOURCE_CONTEXT_DIR} -w" )
      }
    }
  }
}
```

or 

```
stage('Container Build'){
  steps {
    patchBuildConfigOutputLabels(bcName: "${APP_NAME}")
    script {
      openshift.withCluster () {
        openshift.startBuild( "${APP_NAME} --from-dir=${SOURCE_CONTEXT_DIR} -w" )
      }
    }
  }
}
```