### PR TITLE
Add additional checks to verify deployment

### DIFF
--- a/vars/verifyDeployment.groovy
+++ b/vars/verifyDeployment.groovy
@@ -17,9 +17,26 @@ def call(ClusterInput input) {
         openshift.withProject("${input.projectName}") {
             def dcObj = openshift.selector("dc", input.targetApp).object()
             def podSelector = openshift.selector("pod", [deployment: "${input.targetApp}-${dcObj.status.latestVersion}"])
-            podSelector.untilEach {
-                echo "pod: ${it.name()}"
-                return it.object().status.containerStatuses[0].ready
+            podSelector.untilEach { pod ->
+                pod.object().status.containerStatuses.every {
+                    if(it.state.waiting != null) {
+                        if(it.state.waiting.reason == "CrashLoopBackOff") {
+                            echo "Container failing to start. Logs:"
+                            pod.logs()
+                            sh "oc deploy ${appName} --cancel"
+                            error "CrashLoopBackOff"
+                        }
+                        else if(it.state.waiting.reason == "CreateContainerConfigError") {
+                            def message = it.state.waiting.message
+                            echo "Container cannot be created: ${message}"
+                            sh "oc deploy ${appName} --cancel"
+                            error "CreateContainerConfigError : ${message}"
+                        }
+                    }
+                    return pod.object().status.containerStatuses.every {
+                        it.ready
+                    }
+                }                
             }
         }
     }


### PR DESCRIPTION
Check for common failure scenarios (CrashLoopBackOff and CreateContainerConfigError).  Roll back the deployment and error out of the pipeline in the event that an unrecoverable error occurs (instead of waiting for timeout)