### PR TITLE
Fixed applier not running due to incorrect variable

### DIFF
--- a/vars/applier.groovy
+++ b/vars/applier.groovy
@@ -43,7 +43,9 @@ def call(ApplierInput input) {
     }
 
     openshift.withCluster(clusterAPI, clusterToken) {
-        script {
+        openshift.withProject() {
+            openshift.raw("login")
+
             sh """
                 pushd ${input.ansibleRootDir}
                 ansible-galaxy install --role-file=${input.requirementsPath} --roles-path=${input.rolesPath}

--- a/vars/applier.groovy
+++ b/vars/applier.groovy
@@ -26,7 +26,7 @@ def call(ApplierInput input) {
     // else use given clusterToken
     // useful to prevent loading the cluster token from secret over and over again
     // which can be a slow operation but also preserves backward compatibility in this function
-    if(!secretName.allWhitespace) {
+    if(!input.secretName.allWhitespace) {
         openshift.withCluster() {
             def secretData   = openshift.selector("secret/${input.secretName}").object().data
             def encodedToken = secretData.token
@@ -43,10 +43,10 @@ def call(ApplierInput input) {
         script {
             sh """
                 pushd ${input.ansibleRootDir}
-		ansible-galaxy install --role-file=${input.requirementsPath} --roles-path=${input.rolesPath}
-		ansible-playbook -i ${input.inventoryPath} ${input.applierPlaybook} ${input.playbookAdditionalArgs}
+                ansible-galaxy install --role-file=${input.requirementsPath} --roles-path=${input.rolesPath}
+                ansible-playbook -i ${input.inventoryPath} ${input.applierPlaybook} ${input.playbookAdditionalArgs}
             	popd
-	    """
+	        """
         }
     }
 }

--- a/vars/applier.groovy
+++ b/vars/applier.groovy
@@ -21,6 +21,9 @@ def call(Map input) {
 def call(ApplierInput input) {
     assert input.inventoryPath?.trim() : "Param inventoryPath should be defined."
     assert input.requirementsPath?.trim() : "Param requirementsPath should be defined."
+
+    def clusterAPI
+    def clusterToken
     
     // if secretName is given then get cluster token from there
     // else use given clusterToken


### PR DESCRIPTION
#### What is this PR About?
fixed:
- variable secretName is not from input, which causes an unknown property error
- added cluster* variables so scope is local
- added login within openshift closure to force it to create a kubecfg - without login it defaults to pod service account - (original code change from 'oc login' to closure came from: https://github.com/redhat-cop/pipeline-library/pull/42)

#### How do we test this?
Run pipeline.

cc: @redhat-cop/day-in-the-life
