### PR TITLE
Removed container block for buildAndTag

### DIFF
--- a/vars/buildAndTag.groovy
+++ b/vars/buildAndTag.groovy
@@ -28,13 +28,13 @@ def call(BuildAndTagInput input) {
     lock("ocp-buildconfig-${input.imageNamespace}-${input.imageName}") {
         container('jenkins-worker-image-mgmt') {
             script {
-                binaryBuildFromFile(
+                binaryBuild([
                     clusterAPI     : input.clusterAPI,
                     clusterToken   : input.clusterToken,
                     projectName    : input.buildProjectName,
                     buildConfigName: input.imageName,
-                    fromFilePath   : input.fromFilePath
-                )
+                    buildFromPath   : input.fromFilePath
+                ])
 
                 echo "Tag for Build"
                 sh """

--- a/vars/buildAndTag.groovy
+++ b/vars/buildAndTag.groovy
@@ -25,26 +25,20 @@ def call(BuildAndTagInput input) {
     assert input.buildProjectName?.trim() : "Param buildProjectName should be defined."
     assert input.fromFilePath?.trim()     : "Param fromFilePath should be defined."
 
-    lock("ocp-buildconfig-${input.imageNamespace}-${input.imageName}") {
-        container('jenkins-worker-image-mgmt') {
-            script {
-                binaryBuild([
-                    clusterAPI     : input.clusterAPI,
-                    clusterToken   : input.clusterToken,
-                    projectName    : input.buildProjectName,
-                    buildConfigName: input.imageName,
-                    buildFromPath   : input.fromFilePath
-                ])
+    binaryBuild([
+        clusterAPI     : input.clusterAPI,
+        clusterToken   : input.clusterToken,
+        projectName    : input.buildProjectName,
+        buildConfigName: input.imageName,
+        buildFromPath   : input.fromFilePath
+    ])
 
-                echo "Tag for Build"
-                sh """
-                    skopeo copy  \
-                        --authfile /var/run/secrets/kubernetes.io/dockerconfigjson/.dockerconfigjson \
-                        --src-tls-verify=${input.tagSourceTLSVerify} \
-                        --dest-tls-verify=${input.tagDestinationTLSVerify} \
-                        docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:latest docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:${input.imageVersion}
-                """
-            }
-        }
-    }
+    echo "Tag for Build"
+    sh """
+        skopeo copy  \
+            --authfile /var/run/secrets/kubernetes.io/dockerconfigjson/.dockerconfigjson \
+            --src-tls-verify=${input.tagSourceTLSVerify} \
+            --dest-tls-verify=${input.tagDestinationTLSVerify} \
+            docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:latest docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:${input.imageVersion}
+    """
 }


### PR DESCRIPTION
#### What is this PR About?
Two fixes:
- Currently it tries to call "binaryBuildFromFile" which doesn't exist in the library. Updated to call: binaryBuild
- Removed lock/container functions. The lib should not decide/know on what containers it needs to run on. This should be done by the pipeline it's self.

#### How do we test this?
Run pipeline.

cc: @redhat-cop/day-in-the-life
