### PR TITLE
Removed container block for tagAndDeploy

### DIFF
--- a/vars/tagAndDeploy.groovy
+++ b/vars/tagAndDeploy.groovy
@@ -27,26 +27,20 @@ def call(TagAndDeployInput input) {
     assert input.deployDestinationProjectName?.trim()  : "Param deployDestinationProjectName should be defined."
     assert input.deployDestinationVersionTag?.trim()      : "Param deployDestinationVersionTag should be defined."
 
-    container('jenkins-worker-image-mgmt') {
-        script {
-            echo "Tag ${input.imageNamespace}/${input.imageName}:${input.imageVersion} as ${input.imageNamespace}/${input.imageName}:${input.deployDestinationVersionTag}"
-            sh """
-                skopeo copy \
-                    --authfile /var/run/secrets/kubernetes.io/dockerconfigjson/.dockerconfigjson \
-                    --src-tls-verify=${input.tagSourceTLSVerify} \
-                    --dest-tls-verify=${input.tagDestinationTLSVerify} \
-                    docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:${input.imageVersion} docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:${input.deployDestinationVersionTag}
-            """
-        }
-       
-        script {
-            echo "Deploy to ${input.deployDestinationProjectName}"
-            rollout(
-                clusterAPI     : input.clusterAPI,
-                clusterToken   : input.clusterToken,
-                projectName    : input.deployDestinationProjectName,
-                deploymentConfigName: input.imageName
-            )
-        }
-    }
+    echo "Tag ${input.imageNamespace}/${input.imageName}:${input.imageVersion} as ${input.imageNamespace}/${input.imageName}:${input.deployDestinationVersionTag}"
+    sh """
+        skopeo copy \
+            --authfile /var/run/secrets/kubernetes.io/dockerconfigjson/.dockerconfigjson \
+            --src-tls-verify=${input.tagSourceTLSVerify} \
+            --dest-tls-verify=${input.tagDestinationTLSVerify} \
+            docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:${input.imageVersion} docker://${input.registryFQDN}/${input.imageNamespace}/${input.imageName}:${input.deployDestinationVersionTag}
+    """
+
+    echo "Deploy to ${input.deployDestinationProjectName}"
+    rollout(
+        clusterAPI     : input.clusterAPI,
+        clusterToken   : input.clusterToken,
+        projectName    : input.deployDestinationProjectName,
+        deploymentConfigName: input.imageName
+    )
 }


### PR DESCRIPTION
## What is this PR About?
One fix:
- Removed container function. The lib should not decide/know on what containers it needs to run on. This should be done by the pipeline it's self.

#### How do we test this?
Run pipeline.

cc: @redhat-cop/day-in-the-life
