### PR TITLE
Removed exportable option which is not supported on ocp4

### DIFF
--- a/vars/applyTemplate.groovy
+++ b/vars/applyTemplate.groovy
@@ -32,7 +32,7 @@ def call(ApplyTemplateInput input) {
                     def foundObjects = dcSelector.exists()
                     if (foundObjects) { 
                         echo "This DC exists, copying the image value"
-                        def dcObjs = dcSelector.objects( exportable:true )
+                        def dcObjs = dcSelector.objects()
                         echo "Image now: ${dcObjs[0].spec.template.spec.containers[0].image}"
                         o.spec.template.spec.containers[0].image = dcObjs[0].spec.template.spec.containers[0].image
                     }


### PR DESCRIPTION
#### What is this PR About?
Removed exportable option as its been removed in OCP4

#### How do we test this?
Run the pipeline on OCP4

cc: @redhat-cop/day-in-the-life
