### PR TITLE
Added travis checks for missing docs and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ install:
   - mvn -N io.takari:maven:wrapper -Dmaven=3.6.0
   - java -version && javac -version && ./mvnw -version -B
 
+before_script:
+  # Check each method has docs and tests, if missing, fail
+  - find vars -type f -name "*.groovy" -exec bash -c '[ -f vars/$(basename {} .groovy).txt ] || echo "Missing vars/$(basename {} .groovy).txt" >> fail.tmp' \;
+  - find vars -type f -name "*.groovy" -exec bash -c '[ -f test/Jenkinsfile-$(basename {} .groovy) ] || echo "Missing test/Jenkinsfile-$(basename {} .groovy)" >> fail.tmp' \;
+  - [ -f fail.tmp ] && cat fail.tmp && exit 1
+
 script:
   - ./mvnw clean install -B
 


### PR DESCRIPTION
#### What is this PR About?
Docs and tests should be added for all new pipeline-lib methods. If they are not included, fail the build.

#### How do we test this?
Run travis job with missing files, see it fail. Add the files, see it pass.

cc: @redhat-cop/day-in-the-life
