### PR TITLE
Update binaryBuild doc to reflect method changes

### DIFF
--- a/vars/binaryBuild.txt
+++ b/vars/binaryBuild.txt
@@ -4,19 +4,20 @@ This trigger binary build if pointed to BuildConfig with binary -strategy.
 
 Sample usages:
 
-Assumes that artifacts are in directory called "deploy":
+Build from directory
 ```
 stage {
     steps{
-        binaryBuild(projectName: "example", buildConfigName: "hello-world-build")
+        binaryBuild(projectName: "example", buildConfigName: "hello-world-build", buildFromPath: "artifacts")
     }
 }
 ```
-Defined your own artifacts directory:
+
+Build from file
 ```
 stage {
     steps{
-        binaryBuild(projectName: "example", buildConfigName: "hello-world-build", artifactsDirectoryName: "artifacts", buildFrom "--from-dir")
+        binaryBuild(projectName: "example", buildConfigName: "hello-world-build", buildFromPath: "artifacts", buildFromFlag: "--from-file")
     }
 }
 ```


### PR DESCRIPTION
#### What is this PR About?
Updating sample usage in docs to reflect `BinaryBuildInput` changes.

`artifactsDirectoryName` is now `buildFromPath` and required

#### How do we test this?
N/A

cc: @redhat-cop/day-in-the-life
