### PR TITLE
Updated patch build config to use jenkins-client-plugin dsl to allow for multi cluster / project

### DIFF
--- a/vars/patchBuildConfigOutputLabels.groovy
+++ b/vars/patchBuildConfigOutputLabels.groovy
@@ -1,33 +1,47 @@
 #!/usr/bin/env groovy
 
+import groovy.json.JsonOutput
+
 // When using the non-declarative pipeline, git env variables need to be set through scm checkout
-class PatchBuildConfigOutputLabelsInput implements Serializable{
+class PatchBuildConfigOutputLabelsInput implements Serializable {
     String domainPrefix = "com.redhat"
-    String bcName
+    String bcName = ""
+
+    //Optional
+    String clusterAPI = ""
+    String clusterToken = ""
+    String projectName = ""
 }
 
 def call(Map input) {
     call(new PatchBuildConfigOutputLabelsInput(input))
-} 
+}
 
 def call(PatchBuildConfigOutputLabelsInput input) {
-    assert input.bcName?.trim() : "Param bcName (build config name) should be defined"
+    assert input.bcName?.trim(): "Param bcName (build config name) should be defined"
 
     def patch = [
             spec: [
-                output : [
-                    imageLabels : [ 
-                        [ name: "${input.domainPrefix}.jenkins.build.url", value: "${env.BUILD_URL}" ],
-                        [ name: "${input.domainPrefix}.jenkins.build.tag", value: "${env.BUILD_NUMBER}"],
-                        [ name: "${input.domainPrefix}.git.branch", value: "${env.GIT_BRANCH}"],
-                        [ name: "${input.domainPrefix}.git.url", value: "${env.GIT_URL}"],
-                        [ name: "${input.domainPrefix}.git.commit", value: "${env.GIT_COMMIT}"]
+                output: [
+                    imageLabels: [
+                        [name: "${input.domainPrefix}.jenkins.build.url", value: "${env.BUILD_URL}"],
+                        [name: "${input.domainPrefix}.jenkins.build.tag", value: "${env.BUILD_NUMBER}"],
+                        [name: "${input.domainPrefix}.git.branch", value: "${env.GIT_BRANCH}"],
+                        [name: "${input.domainPrefix}.git.url", value: "${env.GIT_URL}"],
+                        [name: "${input.domainPrefix}.git.commit", value: "${env.GIT_COMMIT}"]
                     ]
                 ]
-            ] 
+            ]
         ]
 
-    def patchJson = groovy.json.JsonOutput.toJson(patch)
-
-    sh "oc patch bc ${input.bcName} -p '${patchJson}'"
+    openshift.withCluster(input.clusterAPI, input.clusterToken) {
+        openshift.withProject(input.projectName) {
+            def buildConfig = openshift.selector("bc", input.bcName)
+            if (buildConfig.exists()) {
+                openshift.patch(buildConfig.object(), "'" + JsonOutput.toJson(patch) + "'")
+            } else {
+                error "Failed to find 'bc/${input.bcName}' in ${openshift.project()}"
+            }
+        }
+    }
 }


### PR DESCRIPTION
#### What is this PR About?
Updated patchBuildConfigOutputLabels to use the OCP DSL, instead of shell. This allows the pipeline to be used against a different cluster, or different project than what the service account has as its default.

#### How do we test this?
Following TESTING.md for Jenkinsfile-patchBuildConfigOutputLabels

cc: @redhat-cop/day-in-the-life
