### PR TITLE
Added clusterAPI and clusterToken to methods which support it but dont use it

### DIFF
--- a/vars/clusterCredentials.groovy
+++ b/vars/clusterCredentials.groovy
@@ -1,8 +1,12 @@
 #!/usr/bin/env groovy
 
 class ClusterCredentialsInput implements Serializable {
-    String projectName = ""
     String secretName  = ""
+
+    //Optional - Platform
+    String clusterAPI = ""
+    String clusterToken = ""
+    String projectName = ""
 }
 
 def call(Map input) {
@@ -18,7 +22,7 @@ def call(ClusterCredentialsInput input) {
     def encodedApi
     def encodedToken
 
-    openshift.withCluster() {
+    openshift.withCluster(input.clusterAPI, input.clusterToken) {
         openshift.withProject(input.projectName) {
             def secret = openshift.selector("secret/${input.secretName}")
             def secretObject = secret.object()

--- a/vars/configMap.groovy
+++ b/vars/configMap.groovy
@@ -1,8 +1,12 @@
 #!/usr/bin/env groovy
 
 class ConfigMapInput implements Serializable {
-    String projectName = ""
     String configMapName  = ""
+
+    //Optional - Platform
+    String clusterAPI = ""
+    String clusterToken = ""
+    String projectName = ""
 }
 
 def call(Map input) {
@@ -17,7 +21,7 @@ def call(ConfigMapInput input) {
 
     def configMapData
 
-    openshift.withCluster() {
+    openshift.withCluster(input.clusterAPI, input.clusterToken) {
         openshift.withProject(input.projectName) {
             def configMap = openshift.selector("configmap/${input.configMapName}")
             def configMapObject = configMap.object()

--- a/vars/tagImage.groovy
+++ b/vars/tagImage.groovy
@@ -8,6 +8,10 @@ class TagImageInput implements Serializable {
     String toImageName
     String toImageTag
 
+    //Optional - Platform
+    String clusterAPI = ""
+    String clusterToken = ""
+
     TagImageInput init() {
         if(!toImageName?.trim()) toImageName = sourceImageName
         if(!toImageTag?.trim()) toImageTag = sourceImageTag
@@ -24,7 +28,7 @@ def call(TagImageInput input) {
     assert input.sourceImagePath?.trim() : "Param sourceImagePath should be defined."
     assert input.toImagePath?.trim() : "Param toImagePath should be defined."
 
-    openshift.withCluster() {
+    openshift.withCluster(input.clusterAPI, input.clusterToken) {
         openshift.tag("${input.sourceImagePath}/${input.sourceImageName}:${input.sourceImageTag}", 
                       "${input.toImagePath}/${input.toImageName}:${input.toImageTag}")
     }


### PR DESCRIPTION
#### What is this PR About?
Several methods support calling against another cluster, but dont support the params like the rest of the methods. This PR adds those params so all methods can be called against a cluster the user wants.

#### How do we test this?
Run through TESTING.md

cc: @redhat-cop/day-in-the-life
