### PR TITLE
Added tests to check pipelines fail gracefully if resource is not found

### DIFF
--- a/test/Jenkinsfile-applier-fail-missingsecret
+++ b/test/Jenkinsfile-applier-fail-missingsecret
@@ -1,0 +1,20 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("jenkins-slave-ansible") {
+    stage("SETUP: Set logging to verbose") {
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Run applier for 'build-s2i-executable' and fail") {
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'pipelinelib-testing-my-token', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN']]) {
+            applier([
+                    inventoryPath   : ".applier/hosts",
+                    requirementsPath: "requirements.yml",
+                    ansibleRootDir  : "${WORKSPACE}/containers-quickstarts/build-s2i-executable",
+                    applierPlaybook : "galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml",
+                    secretName      : "doesnt-exist",
+            ])
+        }
+    }
+}

--- a/test/Jenkinsfile-binaryBuild-fail-missingbuildconfig
+++ b/test/Jenkinsfile-binaryBuild-fail-missingbuildconfig
@@ -1,0 +1,26 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("maven") {
+    stage("SETUP: Create build files") {
+        dir("build") {
+            dockerfile = """
+                    FROM scratch
+                    COPY README.md /
+                    """
+
+            writeFile file: "README.md", text: "Test file"
+            writeFile file: "Dockerfile", text: dockerfile
+        }
+
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can build using from-file and fail") {
+        binaryBuild([
+                buildConfigName: "doesnt-exist",
+                buildFromFlag  : "--from-dir",
+                buildFromPath  : "${WORKSPACE}/build/"
+        ])
+    }
+}

--- a/test/Jenkinsfile-clusterCredentials-fail-missingsecret
+++ b/test/Jenkinsfile-clusterCredentials-fail-missingsecret
@@ -1,0 +1,14 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("maven") {
+    stage("SETUP: Set logging to verbose") {
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can get credential and fail") {
+        credentials = clusterCredentials([
+                secretName: "doesnt-exist"
+        ])
+    }
+}

--- a/test/Jenkinsfile-configMap-fail-missingconfigmap
+++ b/test/Jenkinsfile-configMap-fail-missingconfigmap
@@ -1,0 +1,14 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("maven") {
+    stage("SETUP: Set logging to verbose") {
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can get configmap data and fail") {
+        configMapData = configMap([
+                configMapName: "doesnt-exist"
+        ])
+    }
+}

--- a/test/Jenkinsfile-crossClusterPromote-fail-missingsecret
+++ b/test/Jenkinsfile-crossClusterPromote-fail-missingsecret
@@ -1,0 +1,17 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("jenkins-slave-image-mgmt") {
+    stage("SETUP: Set logging to verbose") {
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can promote image from one project to another and fail") {
+        crossClusterPromote([
+                sourceImageName          : "jenkins-slave-ansible",
+                sourceImagePath          : "pipelinelib-testing",
+                destinationImagePath     : "pipelinelib-promotion-testing",
+                targetRegistryCredentials: "doesnt-exist"
+        ])
+    }
+}

--- a/test/Jenkinsfile-rollback-fail-missingdc
+++ b/test/Jenkinsfile-rollback-fail-missingdc
@@ -1,0 +1,14 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("maven") {
+    stage("SETUP: Set logging to verbose") {
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can rollback to earlier version and fail") {
+        rollback([
+                deploymentConfig: "dc/doesnt-exist"
+        ])
+    }
+}

--- a/test/Jenkinsfile-rollout-fail-missingdc
+++ b/test/Jenkinsfile-rollout-fail-missingdc
@@ -1,0 +1,14 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("maven") {
+    stage("SETUP: Set logging to verbose") {
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can rollout to latest version and fail") {
+        rollout([
+                deploymentConfigName: "doesnt-exist"
+        ])
+    }
+}


### PR DESCRIPTION
#### What is this PR About?
Added several tests to check if a non-existent resource (i.e.: missing secret) was passed into the method, it gracefully fails with a valid error.

#### How do we test this?
Following TESTING.md

cc: @redhat-cop/day-in-the-life
