### PR TITLE
Added clusterAPI to methods which have clusterURL as clusterAPI is used more

### DIFF
--- a/vars/applyTemplate.groovy
+++ b/vars/applyTemplate.groovy
@@ -6,6 +6,7 @@ class ApplyTemplateInput implements Serializable{
 
     //Optional - Platform
     String clusterUrl = ""
+    String clusterAPI = ""
     String clusterToken = ""
     String projectName = ""
 }
@@ -15,6 +16,12 @@ def call(Map input) {
 } 
 
 def call(ApplyTemplateInput input) {
+    if (input.clusterUrl?.trim().length() > 0) {
+        echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
+
+        input.clusterAPI = input.clusterUrl
+    }
+
     openshift.withCluster(input.clusterUrl, input.clusterToken) {
         openshift.withProject(input.projectName) {
             def models = openshift.process( "--filename=${input.templateFile}", "--param-file=${input.parameterFile}", "--ignore-unknown-parameters")

--- a/vars/crossClusterPromote.groovy
+++ b/vars/crossClusterPromote.groovy
@@ -11,6 +11,7 @@ class CopyImageInput implements Serializable{
 
     //Optional - Platform
     String clusterUrl = ""
+    String clusterAPI = ""
     String clusterToken = ""
 
     CopyImageInput init() {
@@ -26,6 +27,12 @@ def call(Map input) {
 }
 
 def call(CopyImageInput input) {
+    if (input.clusterUrl?.trim().length() > 0) {
+        echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
+
+        input.clusterAPI = input.clusterUrl
+    }
+
     openshift.withCluster(input.clusterUrl, input.clusterToken) {
         def localToken = readFile("/var/run/secrets/kubernetes.io/serviceaccount/token").trim()
 

--- a/vars/rollback.groovy
+++ b/vars/rollback.groovy
@@ -6,6 +6,7 @@ class Rollback implements Serializable {
 
 	//Optional - Platform
 	String clusterUrl = ""
+	String clusterAPI = ""
 	String clusterToken = ""
 	String projectName = ""
 }
@@ -15,6 +16,12 @@ def call(Map input) {
 }
 
 def call(Rollback input) {
+	if (input.clusterUrl?.trim().length() > 0) {
+		echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
+
+		input.clusterAPI = input.clusterUrl
+	}
+	
 	println "Performing rollback to last successful deployment."
 
 	String rollbackToRevision = ""

--- a/vars/verifyDeployment.groovy
+++ b/vars/verifyDeployment.groovy
@@ -5,6 +5,7 @@ class ClusterInput implements Serializable{
 
     //Optional - Platform
     String clusterUrl = ""
+    String clusterAPI = ""
     String clusterToken = ""
     String projectName = ""
 }
@@ -15,6 +16,12 @@ def call(Map input) {
 }
 
 def call(ClusterInput input) {
+    if (input.clusterUrl?.trim().length() > 0) {
+        echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
+
+        input.clusterAPI = input.clusterUrl
+    }
+
     openshift.withCluster(input.clusterUrl, input.clusterToken) {
         openshift.withProject(input.projectName) {
             def dcObj = openshift.selector("dc", input.targetApp).object()


### PR DESCRIPTION
### What is this PR About?
Currently, there is two params to set the cluster; clusterURL and clusterAPI. This PR updates all methods to use the same, by deprecating clusterURL. clusterAPI is chosen as it is currently used by 70%~ of the methods, compared to clusterURL which is 30%~

As per normal deprecation rules, this PR only warns the user and automatically sets the clusterAPI value. In the future, it will be changed to error the build and finally, remove clusterURL completely.

#### How do we test this?
TESTING.md

cc: @redhat-cop/day-in-the-life
