### PR TITLE
Added missing constructor to allow for empty param method for sonar

### DIFF
--- a/test/Jenkinsfile-sonarqubeStaticAnalysis
+++ b/test/Jenkinsfile-sonarqubeStaticAnalysis
@@ -85,10 +85,7 @@ node("maven") {
         sh "git clone https://github.com/redhat-cop/pipeline-library.git"
 
         dir ("pipeline-library") {
-            sonarqubeStaticAnalysis([
-                    pomFile: "pom.xml",
-                    buildServerWebHookName: "jenkins"
-            ])
+            sonarqubeStaticAnalysis()
         }
     }
 }

--- a/vars/sonarqubeStaticAnalysis.groovy
+++ b/vars/sonarqubeStaticAnalysis.groovy
@@ -1,10 +1,14 @@
 #!/usr/bin/env groovy
 
 class SonarQubeConfigurationInput implements Serializable {
-
+    //Optional
     String pomFile = "pom.xml"
     String buildServerWebHookName = "jenkins"
 
+}
+
+def call() {
+    call(new SonarQubeConfigurationInput())
 }
 
 def call(Map input) {


### PR DESCRIPTION
#### What is this PR About?
Docs say its possible to call the sonar method without params:
- https://github.com/redhat-cop/pipeline-library/blob/master/vars/sonarqubeStaticAnalysis.txt#L17

This is actually not true, you get an params miss-match error. This PR enables this functionality.

#### How do we test this?
TESTING.md

cc: @redhat-cop/day-in-the-life
