### PR TITLE
Added ability to provide http file for applyTemplate

### DIFF
--- a/test/Jenkinsfile-applyTemplate-viahttp
+++ b/test/Jenkinsfile-applyTemplate-viahttp
@@ -1,0 +1,31 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("maven") {
+    stage("SETUP: Create deployment files") {
+        def params = """
+                    NAME=applytemplate-http
+                    DATABASE_SERVICE_NAME=applytemplate-http
+                    """
+
+        writeFile file: "params.txt", text: params
+
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can deploy via http") {
+        applyTemplate([
+                templateFile : "https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/quickstarts/cakephp-mysql.json",
+                parameterFile: "params.txt"
+        ])
+    }
+
+    stage("ASSERT") {
+        openshift.withCluster() {
+            openshift.withProject() {
+                def deployment = openshift.selector("dc", "applytemplate-http")
+                assert deployment.exists()
+            }
+        }
+    }
+}

--- a/vars/applyTemplate.groovy
+++ b/vars/applyTemplate.groovy
@@ -24,7 +24,7 @@ def call(ApplyTemplateInput input) {
 
     openshift.withCluster(input.clusterUrl, input.clusterToken) {
         openshift.withProject(input.projectName) {
-            def fileNameArg = "--filename=${input.templateFile}"
+            def fileNameArg = input.templateFile.toLowerCase().startsWith("http") ? input.templateFile : "--filename=${input.templateFile}"
             def parameterFileArg = input.parameterFile?.trim()?.length() <= 0 ? "" : "--param-file=${input.parameterFile}"
 
             def models = openshift.process(fileNameArg, parameterFileArg, "--ignore-unknown-parameters")


### PR DESCRIPTION
#### What is this PR About?
Although 'oc process --filename' supports http, how the jenkins-client-plugin code is written, if you pass in a URL via filename as the first argument, i thinks you are passing in raw markup:
- https://github.com/openshift/jenkins-client-plugin/blob/master/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy#L778

This PR checks if the filename is http based and passes that as the first arg without the filename option.

#### How do we test this?
Update applyTemplate jenkins file under tests to this PR, and following TESTING.md

cc: @redhat-cop/day-in-the-life
