### PR TITLE
Updated clusterUrl to error if used due to deprecation 

### DIFF
--- a/vars/applyTemplate.groovy
+++ b/vars/applyTemplate.groovy
@@ -17,12 +17,10 @@ def call(Map input) {
 
 def call(ApplyTemplateInput input) {
     if (input.clusterUrl?.trim().length() > 0) {
-        echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
-
-        input.clusterAPI = input.clusterUrl
+        error "clusterUrl is deprecated and will be removed in the next release. Please use 'clusterAPI'"
     }
 
-    openshift.withCluster(input.clusterUrl, input.clusterToken) {
+    openshift.withCluster(input.clusterAPI, input.clusterToken) {
         openshift.withProject(input.projectName) {
             def fileNameArg = input.templateFile.toLowerCase().startsWith("http") ? input.templateFile : "--filename=${input.templateFile}"
             def parameterFileArg = input.parameterFile?.trim()?.length() <= 0 ? "" : "--param-file=${input.parameterFile}"

--- a/vars/crossClusterPromote.groovy
+++ b/vars/crossClusterPromote.groovy
@@ -28,12 +28,10 @@ def call(Map input) {
 
 def call(CopyImageInput input) {
     if (input.clusterUrl?.trim().length() > 0) {
-        echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
-
-        input.clusterAPI = input.clusterUrl
+        error "clusterUrl is deprecated and will be removed in the next release. Please use 'clusterAPI'"
     }
 
-    openshift.withCluster(input.clusterUrl, input.clusterToken) {
+    openshift.withCluster(input.clusterAPI, input.clusterToken) {
         def localToken = readFile("/var/run/secrets/kubernetes.io/serviceaccount/token").trim()
 
         def secretData = openshift.selector("secret/${input.targetRegistryCredentials}").object().data

--- a/vars/rollback.groovy
+++ b/vars/rollback.groovy
@@ -17,9 +17,7 @@ def call(Map input) {
 
 def call(Rollback input) {
 	if (input.clusterUrl?.trim().length() > 0) {
-		echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
-
-		input.clusterAPI = input.clusterUrl
+		error "clusterUrl is deprecated and will be removed in the next release. Please use 'clusterAPI'"
 	}
 	
 	println "Performing rollback to last successful deployment."
@@ -30,7 +28,7 @@ def call(Rollback input) {
 		rollbackToRevision = "--to-revision=" + input.rollbackVersion
 	}
 
-	openshift.withCluster(input.clusterUrl, input.clusterToken) {
+	openshift.withCluster(input.clusterAPI, input.clusterToken) {
 		openshift.withProject(input.projectName) {
 			openshift.selector(input.deploymentConfig).rollout().undo(rollbackToRevision)
 		}

--- a/vars/verifyDeployment.groovy
+++ b/vars/verifyDeployment.groovy
@@ -17,12 +17,10 @@ def call(Map input) {
 
 def call(ClusterInput input) {
     if (input.clusterUrl?.trim().length() > 0) {
-        echo "WARNING: clusterUrl is deprecated. Please use 'clusterAPI'"
-
-        input.clusterAPI = input.clusterUrl
+        error "clusterUrl is deprecated and will be removed in the next release. Please use 'clusterAPI'"
     }
 
-    openshift.withCluster(input.clusterUrl, input.clusterToken) {
+    openshift.withCluster(input.clusterAPI, input.clusterToken) {
         openshift.withProject(input.projectName) {
             def dcObj = openshift.selector("dc", input.targetApp).object()
             def podSelector = openshift.selector("pod", [deployment: "${input.targetApp}-${dcObj.status.latestVersion}"])


### PR DESCRIPTION
#### What is this PR About?
Since we've released a new version and clusterUrl is deprecated, have changed the echo to error the pipeline.

#### How do we test this?
TESTING.md

cc: @redhat-cop/day-in-the-life
