### PR TITLE
Fixed cancelling deployment if verify hits a non-recoverable error

### DIFF
--- a/test/Jenkinsfile-verifyDeployment-fail-viacrashloop
+++ b/test/Jenkinsfile-verifyDeployment-fail-viacrashloop
@@ -1,0 +1,24 @@
+#!groovy
+@Library(["pipeline-library@master"]) _
+
+node("maven") {
+    stage("SETUP: Create deployment files") {
+        openshift.withCluster() {
+            openshift.withProject() {
+                def model = openshift.process("https://raw.githubusercontent.com/openshift/origin/v3.11.0/examples/quickstarts/cakephp-mysql.json", "-p NAME=verifydeployment-fail-viacrashloop", "-p DATABASE_SERVICE_NAME=verifydeployment-fail-viacrashloop")
+                openshift.apply(model)
+
+                openshift.patch(openshift.selector("dc", "verifydeployment-fail-viacrashloop").object(), "'{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"mysql\",\"env\":null}]}}}}'")
+
+                //HACK: Wait for the deployment to be trigger
+                sh "sleep 5"
+            }
+        }
+    }
+
+    stage("TEST: Can verify deployment and fail with due to crashloopbackoff") {
+        verifyDeployment([
+                targetApp: "verifydeployment-fail-viacrashloop"
+        ])
+    }
+}


### PR DESCRIPTION
#### What is this PR About?
verifyDeployment mixes sh and dsl to interact with OC, since dsl is the prefered way for the lib, have updated to use dsl.

Also, the sh commands reference a property (appName) that doesn't exist, which causes the following error:
`MissingPropertyException: No such property: appName for class: verifyDeployment`

#### How do we test this?
Following TESTING.md against master for the new test, see the error. Follow against this PR, see it working as expected - i.e.: job fails due to crashloopbackoff.

cc: @redhat-cop/day-in-the-life
