### PR TITLE
Updated rollout / rollback to allow for different kinds to be supported

### DIFF
--- a/test/Jenkinsfile-rollback
+++ b/test/Jenkinsfile-rollback
@@ -30,7 +30,7 @@ node("maven") {
 
     stage("TEST: Can rollback to earlier version") {
         rollback([
-                deploymentConfig: "dc/rollback"
+                resourceKindAndName: "dc/rollback"
         ])
     }
 

--- a/test/Jenkinsfile-rollback-fail-missingdc
+++ b/test/Jenkinsfile-rollback-fail-missingdc
@@ -8,7 +8,7 @@ node("maven") {
 
     stage("TEST: Can rollback to earlier version and fail") {
         rollback([
-                deploymentConfig: "dc/doesnt-exist"
+                resourceKindAndName: "dc/doesnt-exist"
         ])
     }
 }

--- a/test/Jenkinsfile-rollout
+++ b/test/Jenkinsfile-rollout
@@ -24,7 +24,7 @@ node("maven") {
 
     stage("TEST: Can rollout to latest version") {
         rollout([
-                deploymentConfigName: "rollout"
+                resourceKindAndName: "dc/rollout"
         ])
     }
 

--- a/test/Jenkinsfile-rollout-deployment
+++ b/test/Jenkinsfile-rollout-deployment
@@ -1,0 +1,34 @@
+#!groovy
+@Library(["pipeline-library@rollout-rollback-resource"]) _
+
+node("maven") {
+    stage("SETUP: Create deployment files") {
+        openshift.withCluster() {
+            openshift.withProject() {
+                openshift.apply("-f", "https://raw.githubusercontent.com/kubernetes/examples/master/guestbook/all-in-one/guestbook-all-in-one.yaml")
+
+                openshift.patch(openshift.selector("deployment", "redis-master").object(), "'{\"spec\":{\"replicas\":0}}'")
+                openshift.patch(openshift.selector("deployment", "redis-slave").object(), "'{\"spec\":{\"replicas\":1}}'")
+                openshift.patch(openshift.selector("deployment", "frontend").object(), "'{\"spec\":{\"replicas\":0}}'")
+            }
+        }
+
+        openshift.logLevel(10)
+    }
+
+    stage("TEST: Can rollout a k8s deployment") {
+        rollout([
+                resourceKindAndName: "deployment/redis-slave",
+                latest: false
+        ])
+    }
+
+    stage("ASSERT") {
+        openshift.withCluster() {
+            openshift.withProject() {
+                def deployment = openshift.selector("deployment", "redis-slave")
+                assert deployment.object().status.availableReplicas == 1
+            }
+        }
+    }
+}

--- a/test/Jenkinsfile-rollout-fail-missingdc
+++ b/test/Jenkinsfile-rollout-fail-missingdc
@@ -8,7 +8,7 @@ node("maven") {
 
     stage("TEST: Can rollout to latest version and fail") {
         rollout([
-                deploymentConfigName: "doesnt-exist"
+                resourceKindAndName: "dc/doesnt-exist"
         ])
     }
 }

--- a/vars/tagAndDeploy.groovy
+++ b/vars/tagAndDeploy.groovy
@@ -50,7 +50,7 @@ def call(TagAndDeployInput input) {
         clusterAPI     : input.clusterAPI,
         clusterToken   : input.clusterToken,
         projectName    : input.deployDestinationProjectName,
-        deploymentConfigName: input.imageName,
+        resourceKindAndName: "deploymentconfig/${input.imageName}",
         loglevel: input.loglevel
     )
 }


### PR DESCRIPTION
#### What is this PR About?
Updates rollout/rollback to support different kinds, which include: ["DeploymentConfig","Deployment","DaemonSet","StatefulSet"]

Also, adds an extra flag to allow the caller to decide if they want latest or not on rollout

#### How do we test this?
Follow: https://github.com/redhat-cop/pipeline-library/pull/94

cc: @redhat-cop/day-in-the-life
