### PR TITLE
Added scale to 0 replicas once test is finished for envs with restrictive quotas

### DIFF
--- a/test/Jenkinsfile-applyTemplate
+++ b/test/Jenkinsfile-applyTemplate
@@ -20,6 +20,9 @@ node("maven") {
             openshift.withProject() {
                 def deployment = openshift.selector("dc", "cakephp-mysql-example")
                 assert deployment.exists()
+
+                //Scale down afterwards to lower quotas
+                deployment.scale("--replicas=0")
             }
         }
     }

--- a/test/Jenkinsfile-applyTemplate-viahttp
+++ b/test/Jenkinsfile-applyTemplate-viahttp
@@ -25,6 +25,9 @@ node("maven") {
             openshift.withProject() {
                 def deployment = openshift.selector("dc", "applytemplate-http")
                 assert deployment.exists()
+
+                //Scale down afterwards to lower quotas
+                deployment.scale("--replicas=0")
             }
         }
     }

--- a/test/Jenkinsfile-applyTemplate-withparams
+++ b/test/Jenkinsfile-applyTemplate-withparams
@@ -27,6 +27,9 @@ node("maven") {
             openshift.withProject() {
                 def deployment = openshift.selector("dc", "applytemplate")
                 assert deployment.exists()
+
+                //Scale down afterwards to lower quotas
+                deployment.scale("--replicas=0")
             }
         }
     }

--- a/test/Jenkinsfile-rollback
+++ b/test/Jenkinsfile-rollback
@@ -51,6 +51,9 @@ node("maven") {
                 def third = openshift.selector("rc", "rollback-${firstDeploymentVersion + 2}")
                 assert third.exists()
                 assert third.object().spec.template.metadata.labels.version == null
+
+                //Scale down afterwards to lower quotas
+                deployment.scale("--replicas=0")
             }
         }
     }

--- a/test/Jenkinsfile-rollout
+++ b/test/Jenkinsfile-rollout
@@ -38,6 +38,9 @@ node("maven") {
 
                 def rc = openshift.selector("rc", "rollout-${nextRcNumber}")
                 assert rc.exists()
+
+                //Scale down afterwards to lower quotas
+                deployment.scale("--replicas=0")
             }
         }
     }

--- a/test/Jenkinsfile-tagAndDeploy
+++ b/test/Jenkinsfile-tagAndDeploy
@@ -54,6 +54,10 @@ podTemplate(label: "jnlp", cloud: "openshift", inheritFrom: "jenkins-slave-image
                     imageStream.untilEach(1) {
                         return it.object().status?.tags?.size() == 2
                     }
+
+                    //Scale down afterwards to lower quotas
+                    def deployment = openshift.selector("dc", "taganddeploy")
+                    deployment.scale("--replicas=0")
                 }
             }
         }

--- a/test/Jenkinsfile-verifyDeployment
+++ b/test/Jenkinsfile-verifyDeployment
@@ -24,6 +24,9 @@ node("maven") {
             openshift.withProject() {
                 def deployment = openshift.selector("dc", "verifydeployment")
                 deployment.rollout().status("--watch=true")
+
+                //Scale down afterwards to lower quotas
+                deployment.scale("--replicas=0")
             }
         }
     }


### PR DESCRIPTION
#### What is this PR About?
For environments which have quotas (i.e.: opentlc shared), the tests that run last fail as they cannot start due to the previous tests using all the quota. This PR downscales any pods once the test has finished successfully.

#### How do we test this?
TESTING.md or https://github.com/redhat-cop/pipeline-library/pull/94

cc: @redhat-cop/day-in-the-life
