### PR TITLE
Updated applier test to use testing namespace naming

### DIFF
--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -112,6 +112,7 @@ openshift_cluster_content:
         resource: jenkins
     - role: casl-ansible/roles/openshift-route-status
       vars:
+        target_namespace: "{{ namespace }}"
         route: jenkins
         protocol: https
         status: 200

--- a/TESTING.md
+++ b/TESTING.md
@@ -87,5 +87,5 @@ find test -type f -name "Jenkinsfile-*" -exec bash -c 'oc start-build $(basename
 
 ### Cleanup
 ```bash
-oc delete project pipelinelib-testing pipelinelib-promotion-testing build-s2i-executable sonarqube
+oc delete project pipelinelib-testing{,-promotion-testing,-build-s2i-executable,-sonarqube}
 ```

--- a/test/Jenkinsfile-applier
+++ b/test/Jenkinsfile-applier
@@ -1,8 +1,14 @@
 #!groovy
 @Library(["pipeline-library@master"]) _
 
+def applierNamespace
+def testingNamespace
+
 node("jenkins-slave-ansible") {
     stage("SETUP: Clone containers-quickstarts") {
+        testingNamespace = sh(script: "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace", returnStdout: true)
+        applierNamespace = testingNamespace + '-build-s2i-executable'
+
         sh "git clone https://github.com/redhat-cop/containers-quickstarts.git"
 
         openshift.logLevel(10)
@@ -15,6 +21,7 @@ node("jenkins-slave-ansible") {
                     requirementsPath: "requirements.yml",
                     ansibleRootDir  : "${WORKSPACE}/containers-quickstarts/build-s2i-executable",
                     applierPlaybook : "galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml",
+                    playbookAdditionalArgs: "-e namespace=${applierNamespace}",
                     clusterAPI      : "https://kubernetes.default.svc",
                     clusterToken    : "${TOKEN}"
             ])
@@ -24,7 +31,7 @@ node("jenkins-slave-ansible") {
     stage("ASSERT") {
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'pipelinelib-testing-my-token', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN']]) {
             openshift.withCluster("https://kubernetes.default.svc", "${TOKEN}") {
-                openshift.withProject("build-s2i-executable") {
+                openshift.withProject(applierNamespace) {
                     def buildConfig = openshift.selector("bc", "build-s2i-executable")
                     assert buildConfig.exists()
                 }

--- a/test/Jenkinsfile-buildAndTag
+++ b/test/Jenkinsfile-buildAndTag
@@ -11,6 +11,7 @@ podTemplate(label: "jnlp", cloud: "openshift", inheritFrom: "jenkins-slave-image
     node("jnlp") {
         stage("SETUP: Create build files") {
             testingNamespace = sh(script: "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace", returnStdout: true)
+
             openshift.withCluster() {
                 openshift.withProject("openshift") {
                     def imageStream = openshift.selector("is", "jenkins")

--- a/test/Jenkinsfile-crossClusterPromote
+++ b/test/Jenkinsfile-crossClusterPromote
@@ -8,6 +8,7 @@ node("jenkins-slave-image-mgmt") {
     stage("SETUP: Check imagestream doesnt exist") {
         testingNamespace = sh(script: "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace", returnStdout: true)
         promotionNamespace = testingNamespace + '-promotion-testing'
+
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'pipelinelib-testing-my-token', usernameVariable: 'USERNAME', passwordVariable: 'TOKEN']]) {
             openshift.withCluster("https://kubernetes.default.svc", "${TOKEN}") {
                 try {

--- a/test/Jenkinsfile-imageMirror
+++ b/test/Jenkinsfile-imageMirror
@@ -10,6 +10,7 @@ node("maven") {
         openshift.withCluster() {
             testingNamespace = sh(script: "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace", returnStdout: true)
             promotionNamespace = testingNamespace + '-promotion-testing'
+
             openshift.withProject("openshift") {
                 def imageStream = openshift.selector("is", "jenkins")
                 dockerRegistry = sh(returnStdout: true, script: "echo '${imageStream.object().status.dockerImageRepository}' | cut -d '/' -f1").trim()

--- a/test/Jenkinsfile-sonarqubeStaticAnalysis
+++ b/test/Jenkinsfile-sonarqubeStaticAnalysis
@@ -7,6 +7,7 @@ def sonarqubeNamespace
 node("jenkins-slave-ansible") {
     stage("SETUP: Deploy sonarqube via applier") {
         sonarqubeNamespace = sh(script: "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace", returnStdout: true) + '-sonarqube'
+
         sh "git clone https://github.com/redhat-cop/containers-quickstarts.git"
 
         openshift.withCluster() {

--- a/test/Jenkinsfile-tagImage
+++ b/test/Jenkinsfile-tagImage
@@ -4,8 +4,11 @@
 def testingNamespace
 
 node("maven") {
-    stage("TEST: Can tag image") {
+    stage("SETUP: Resolve namespace") {
         testingNamespace = sh(script: "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace", returnStdout: true)
+    }
+
+    stage("TEST: Can tag image") {
         tagImage([
                 sourceImagePath: "openshift",
                 sourceImageName: "jenkins",


### PR DESCRIPTION
#### What is this PR About?
Updates applier to use custom namespace. As i had some spare time, thought i'd do the work.
- https://github.com/redhat-cop/pipeline-library/pull/104#pullrequestreview-334567492

#### How do we test this?
> ./_test/setup.sh applier pipelinelib-testing garethahealy/pipeline-library applier-ns && ./_test/setup.sh test

Check project 'pipelinelib-testing-build-s2i-executable' exists.

cc: @redhat-cop/day-in-the-life
