### PR TITLE
Explicitly look up build instead using the return value of startBuild…

### DIFF
--- a/vars/binaryBuild.groovy
+++ b/vars/binaryBuild.groovy
@@ -29,9 +29,16 @@ def call(BinaryBuildInput input) {
             echo "Attemping to start and follow 'buildconfig/${input.buildConfigName}' in ${openshift.project()}"
 
             def buildConfig = openshift.selector('bc', input.buildConfigName)
-            buildConfig.startBuild("${input.buildFromFlag}=${input.buildFromPath}", '--wait')
-            def build = buildConfig.related('builds')
-            build.logs('-f')
+            def build = buildConfig.startBuild("${input.buildFromFlag}=${input.buildFromPath}", '--wait')
+            if (build.names().size() > 1) {
+                build.withEach {
+                    if (it.name().contains(input.buildConfigName)) {
+                        it.logs('-f')
+                    }
+                }
+            } else {
+                build.logs('-f')
+            }
         }
     }
 }

--- a/vars/binaryBuild.groovy
+++ b/vars/binaryBuild.groovy
@@ -31,11 +31,10 @@ def call(BinaryBuildInput input) {
             def buildConfig = openshift.selector('bc', input.buildConfigName)
             def build = buildConfig.startBuild("${input.buildFromFlag}=${input.buildFromPath}", '--wait')
             if (build.names().size() > 1) {
-                build.withEach {
-                    if (it.name().contains(input.buildConfigName)) {
-                        it.logs('-f')
-                    }
-                }
+                def buildConfigObject = buildConfig.object()
+                def buildVersion = buildConfigObject.status?.lastVersion
+                def latestBuild = openshift.selector("build", "${input.buildConfigName}-${buildVersion}")
+                latestBuild.logs('-f')
             } else {
                 build.logs('-f')
             }

--- a/vars/binaryBuild.groovy
+++ b/vars/binaryBuild.groovy
@@ -29,7 +29,8 @@ def call(BinaryBuildInput input) {
             echo "Attemping to start and follow 'buildconfig/${input.buildConfigName}' in ${openshift.project()}"
 
             def buildConfig = openshift.selector('bc', input.buildConfigName)
-            def build       = buildConfig.startBuild("${input.buildFromFlag}=${input.buildFromPath}", '--wait')
+            buildConfig.startBuild("${input.buildFromFlag}=${input.buildFromPath}", '--wait')
+            def build = buildConfig.related('builds')
             build.logs('-f')
         }
     }


### PR DESCRIPTION
#### What is this PR About?
We were having issues when using the `binaryBuild` method with an npm project (Seems to work fine as is with spring)

After some investigation we found the `.startBuild` method was returning a selector that looked like this
`selector([name=null],[labels=null],[namelist=[Uploading directory "build" as binary input for the build ..., ., Uploading finished, build/manager-360-front-3]],[projectlist=null]`

Which caused the log errors
`[logs:.] error: invalid resource name ".": [may not be '.']`
`[logs:Uploading finished] Error from server (NotFound): pods "Uploading" not found`

This change just explicitly looks up the build information based on the build config and the related method rather then depending on the startBuild return value. 

#### How do we test this?
Replaced the `binaryBuild` method with this modified version, and we were able to see the build logs in our pipeline. 


cc: @redhat-cop/day-in-the-life
