### PR TITLE
Fix ansible indentation + branch checkout for testing

### DIFF
--- a/_test/setup.sh
+++ b/_test/setup.sh
@@ -8,8 +8,7 @@ CLONE_DIR="/tmp/${CI_REPO_SLUG}/${CI_BRANCH}"
 
 clone() {
   rm -rf ${CLONE_DIR}
-  git clone "https://github.com/${CI_REPO_SLUG}.git" ${CLONE_DIR}
-  git checkout ${CI_BRANCH}
+  git clone -b ${CI_BRANCH} "https://github.com/${CI_REPO_SLUG}.git" ${CLONE_DIR}
 }
 
 applier() {

--- a/roles/configure-jenkins/tasks/main.yml
+++ b/roles/configure-jenkins/tasks/main.yml
@@ -12,10 +12,10 @@
     headers:
       Authorization: "Bearer {{ oc_token }}"
     validate_certs: no
-    retries: "{{ retries|int }}"
-    delay: "{{ delay|int }}"
-    register: createlib_result
-    until: createlib_result is not failed
+  retries: "{{ retries|int }}"
+  delay: "{{ delay|int }}"
+  register: createlib_result
+  until: createlib_result is not failed
 
 - name: Install plugins
   uri:
@@ -29,10 +29,10 @@
       Authorization: "Bearer {{ oc_token }}"
       Content-Type: text/xml
     validate_certs: no
-    retries: "{{ retries|int }}"
-    delay: "{{ delay|int }}"
-    register: plugininstall_result
-    until: plugininstall_result is not failed
+  retries: "{{ retries|int }}"
+  delay: "{{ delay|int }}"
+  register: plugininstall_result
+  until: plugininstall_result is not failed
   with_items:
   - sonar@2.10
   - openshift-client@1.0.32


### PR DESCRIPTION
#### What is this PR About?
Newer versions of Ansible will error because indentation in tasks.

Use `git clone -b <branch> <repo>` to checkout the desired branch during testing.

#### How do we test this?
Normally CI should go green but there are known issues with the testing of this repo (will be fixed in a follow up PR).
In the meantime the following should be enough (with Ansible 2.9+)
```bash
./_test/setup.sh applier pipeline-testing pabrahamsson/pipeline-library ansible_task_indentation
```
Verify that
- The above command runs successfully
- `/tmp/pabrahamsson/pipeline-library/ansible_task_indentation` has been created and has `ansible_task_indentation` branch checked out

cc: @redhat-cop/day-in-the-life
